### PR TITLE
add enemy patrol class

### DIFF
--- a/Assets/Sprint 3/Enemy AI Patrol.meta
+++ b/Assets/Sprint 3/Enemy AI Patrol.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 97fd867bbf8004bf0b838be061fa3b30
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprint 3/Enemy AI Patrol/EnemyPatrol.cs
+++ b/Assets/Sprint 3/Enemy AI Patrol/EnemyPatrol.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyPatrol : StateBaseClass
+{
+    [SerializeField]
+    public float speed = 5;
+    
+    // x: x value of waypoint
+    // y: y value of waypoint
+    // z: time in seconds to wait at that waypoint
+    public Vector3[] waypoints;
+    private Vector3 targetPos;
+    private Vector2 velocity;
+    private int index;
+    private bool waiting;   
+
+    IEnumerator lookAround(float time)
+    {
+        waiting = true;
+
+        // put animation code here
+        yield return new WaitForSeconds(time);
+
+        waiting = false;
+    }
+    public override void Init(){
+        waiting = false;
+        index = 0;
+        targetPos = waypoints[index];
+    }
+    public override void On_Update(){
+        if ((Vector2)transform.position == (Vector2)targetPos) // Goes to the next waypoint if the current one is reached
+        {
+            StartCoroutine(lookAround(targetPos.z));
+            if (index < waypoints.Length)
+            {
+                index++;
+            }
+            index = index % waypoints.Length;
+            StartCoroutine(lookAround(targetPos.z));
+            targetPos = waypoints[index];
+        }
+
+        if(!waiting)
+        {
+            velocity = Vector2.MoveTowards(transform.position, targetPos, speed * Time.deltaTime); 
+        }
+
+        transform.position = velocity;
+
+        // face towards target
+        Vector3 diff = targetPos - transform.position;
+        diff.Normalize();
+        transform.rotation = Quaternion.Euler(0f, 0f, Mathf.Atan2(diff.y, diff.x) * Mathf.Rad2Deg - 90);
+    }
+}

--- a/Assets/Sprint 3/Enemy AI Patrol/EnemyPatrol.cs.meta
+++ b/Assets/Sprint 3/Enemy AI Patrol/EnemyPatrol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37e2e1c9ca31043c2bb4eb7355cbc772
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds EnemyPatrol, which is a class that extends the StateBaseClass. Did not edit the Enemy prefab  to use new EnemyPatrol component. Patrol path can be set in Editor. State change mechanics not implemented.