### PR TITLE
Fixed Volume Slider Not Working

### DIFF
--- a/Assets/Scenes/FinalMainMenu.unity
+++ b/Assets/Scenes/FinalMainMenu.unity
@@ -4918,9 +4918,9 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: OptionMenu, Assembly-CSharp
-        m_MethodName: SetVolume
+      - m_Target: {fileID: 1772561828}
+        m_TargetAssemblyTypeName: MainMenu, Assembly-CSharp
+        m_MethodName: volumeChange
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/UI Scripts/Menu/MainMenu.cs
+++ b/Assets/Scripts/UI Scripts/Menu/MainMenu.cs
@@ -31,6 +31,10 @@ public class MainMenu : MonoBehaviour
         Application.Quit();
     }
 
+    public void volumeChange(float sliderVolume)
+    {
+        audioManager.masterVolume = sliderVolume;
+    }
     IEnumerator FadeToBlackAndLoadScene()
     {
         fadeOutUIImage.gameObject.SetActive(true);

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -20,7 +20,10 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Floor2Dungeon.unity
     guid: f7a3fb51f77e5db40943a1c0c15c31e3
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/OLD Death.unity
     guid: 7ae11b08bbab61a43a4df388bc29f1af
+  - enabled: 1
+    path: Assets/Scenes/Test Scenes/Tristyn/Tristyn.unity
+    guid: 512953ab316e44a879e6a8ea02b68ed2
   m_configObjects: {}

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -21,6 +21,6 @@ EditorBuildSettings:
     path: Assets/Scenes/Floor2Dungeon.unity
     guid: f7a3fb51f77e5db40943a1c0c15c31e3
   - enabled: 1
-    path: Assets/Scenes/Death.unity
+    path: Assets/Scenes/OLD Death.unity
     guid: 7ae11b08bbab61a43a4df388bc29f1af
   m_configObjects: {}


### PR DESCRIPTION
Added public function to MainMenu script which changes the master Volume value in the audio manager in GlobalTeapot.

VolumeSlider in options menu calls the script created above to change the value of master volume to value of the slider.